### PR TITLE
Fix 404 error when path contains encoded values

### DIFF
--- a/src/scripts/router.js
+++ b/src/scripts/router.js
@@ -31,7 +31,7 @@ define(['knockout', 'jquery'], function(ko, $) {
     function pageFromMapping(path) {
       for (key in self.urlMapping) {
         var mapping = self.urlMapping[key];
-        var matches = mapping.match.exec(path);
+        var matches = mapping.match.exec(decodeURIComponent(path));
         if (matches) {
           // Pass the group matches from the regex.
           return mapping.page.apply(this, matches.slice(1));


### PR DESCRIPTION
Found a small bug when I used encodeURIComponent() to put values into the URL. It wasn't doing a decodeURIComponent when trying to find a match URL mapping.